### PR TITLE
Update GitHub actions to only run on PRs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,6 @@
 name: CI
-on: [push]
+on:
+  pull_request: {}
 jobs:
   formatting-and-linting:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Context

In https://github.com/chubberlisk/chubberlisk/pull/4, GitHub actions workflow was added to run formatting, linting and end to end tests but it ran on `push`.

## Changes proposed in this pull request

Update GitHub actions to run on `pull_request` instead of `push`. Hopefully this means that it doesn't run on `master`.

## Guidance to review

:ship:

## Link to Trello card

N/A