### PR TITLE
Add styling for smoller devices

### DIFF
--- a/src/components/core/Footer/index.module.css
+++ b/src/components/core/Footer/index.module.css
@@ -5,3 +5,9 @@
 .copyrightText {
   @apply text-sm;
 }
+
+@media (max-width: 640px) {
+  .copyrightText {
+    @apply text-xs;
+  }
+}

--- a/src/components/custom/ContactMeSection/index.module.css
+++ b/src/components/custom/ContactMeSection/index.module.css
@@ -31,6 +31,21 @@
 .contactMeSocialLinksListItem {
   @apply inline;
 }
+
 .contactMeSocialLinksListItem:nth-child(odd) {
   @apply mr-5;
+}
+
+@media (max-width: 640px) {
+  .contactMeSlogan {
+    @apply text-base;
+  }
+
+  .contactMeSocialLink {
+    @apply text-base;
+  }
+
+  .contactMeTitle {
+    @apply text-2xl;
+  }
 }

--- a/src/pages/styles.css
+++ b/src/pages/styles.css
@@ -29,6 +29,28 @@ p {
   @apply text-lg;
 }
 
+@media (max-width: 640px) {
+  h1 {
+    @apply text-4xl;
+  }
+
+  h2 {
+    @apply text-3xl;
+  }
+
+  h3 {
+    @apply text-2xl;
+  }
+
+  h4 {
+    @apply text-xl;
+  }
+
+  p {
+    @apply text-base;
+  }
+}
+
 mark {
   padding: 0 0.5rem;
 }


### PR DESCRIPTION
## Context

On smoller devices, the font sizes are disproportionate. 

## Changes proposed in this pull request

Add styling for smoller devices.

| Before | After |
|--------|-------|
|![image](https://user-images.githubusercontent.com/42817036/83671945-646d8800-a5cd-11ea-903c-fead639b8a9a.png)|![image](https://user-images.githubusercontent.com/42817036/83671902-54ee3f00-a5cd-11ea-8f52-0f9f085071d8.png)|

## Guidance to review

:ship: 

## Link to Trello card

N/A
